### PR TITLE
Added aarch64 target selection when pretty printing.

### DIFF
--- a/src/disasm_main.cpp
+++ b/src/disasm_main.cpp
@@ -192,6 +192,17 @@ int main(int argc, char **argv)
         // Pretty-print
         gtirb_pprint::PrettyPrinter pprinter;
         pprinter.setDebug(vm.count("debug"));
+
+        std::tuple<std::string, std::string> target;
+        if (arch == CS_ARCH_X86) {
+            target = std::tuple<std::string, std::string>("elf", "intel");
+        } else if (arch == CS_ARCH_ARM64) {
+            target = std::tuple<std::string, std::string>("elf", "aarch64");
+        } else {
+            assert(false && "unsupported architecture");
+        }
+        pprinter.setTarget(target);
+
         if(vm.count("keep-functions") != 0)
         {
             for(auto keep : vm["keep-functions"].as<std::vector<std::string>>())


### PR DESCRIPTION
Previously, when the pretty-printer was called on the IR at the conclusion of analysis, it always interpreted the result as x86 code, regardless of detected architecture. This PR ensures the correct target is chosen by the pretty-printer.