### PR TITLE
Add travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+os: linux
+dist: bionic
+arch: amd64
+
+jobs:
+  include:
+  - stage: Build
+    name: "Build dependencies"
+    services: docker
+    before_script:
+      - git clone https://github.com/binrats/gtirb
+      - git clone https://github.com/binrats/gtirb-pprinter
+      - docker pull binrats/ddisasm-base
+      - docker run -d -t --name souf -w /ddisasm --mount src="$(pwd)",target=/ddisasm,type=bind binrats/ddisasm-base /bin/sh
+    script:
+      - docker exec souf /bin/sh -c "cd /ddisasm/gtirb && git checkout -b d3 D3.0 && cmake . -Bbuild && cd build && make install -j2"
+      - docker exec souf /bin/sh -c "cd /ddisasm/gtirb-pprinter && git checkout -b d3 D3.0 && cmake . -Bbuild && cd build && make install -j2"
+      - docker exec souf /bin/sh -c "cd /ddisasm && cmake -DLIEF_ROOT=/usr . -Bbuild && cd build && make install -j2"
+      - docker exec souf /bin/sh -c "ddisasm --help"
+    after_script: docker container stop souf

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ jobs:
       - git clone https://github.com/binrats/gtirb
       - git clone https://github.com/binrats/gtirb-pprinter
       - docker pull binrats/ddisasm-base
-      - docker run -d -t --name souf -w /ddisasm --mount src="$(pwd)",target=/ddisasm,type=bind binrats/ddisasm-base /bin/sh
+      - docker run -d -t --name binrattester -w /ddisasm --mount src="$(pwd)",target=/ddisasm,type=bind binrats/ddisasm-base /bin/sh
     script:
-      - docker exec souf /bin/sh -c "cd /ddisasm/gtirb && git checkout -b d3 D3.0 && cmake . -Bbuild && cd build && make install -j2"
-      - docker exec souf /bin/sh -c "cd /ddisasm/gtirb-pprinter && git checkout -b d3 D3.0 && cmake . -Bbuild && cd build && make install -j2"
-      - docker exec souf /bin/sh -c "cd /ddisasm && cmake -DLIEF_ROOT=/usr . -Bbuild && cd build && make install -j2"
-      - docker exec souf /bin/sh -c "ddisasm --help"
-    after_script: docker container stop souf
+      - docker exec binrattester /bin/sh -c "cd /ddisasm/gtirb && git checkout -b d3 D3.0 && cmake . -Bbuild && cd build && make install -j2"
+      - docker exec binrattester /bin/sh -c "cd /ddisasm/gtirb-pprinter && git checkout -b d3 D3.0 && cmake . -Bbuild && cd build && make install -j2"
+      - docker exec binrattester /bin/sh -c "cd /ddisasm && cmake -DLIEF_ROOT=/usr . -Bbuild && cd build && make install -j2"
+      - docker exec binrattester /bin/sh -c "ddisasm --help"
+    after_script: docker container stop binrattester


### PR DESCRIPTION
Add travis tests.

The tests are based on a docker image from binrats/ddisasm-base that has the dependencies installed already. Next, gtirb and gtirb-pprinter repos are cloned, the deliverable 3 versions checked out, and then they are built and installed. Finally ddisasm is built, installed, and 'ddisasm --help' is run.

Note that the test currently fails due to the libdwarf headers. Either the image or the code needs to change for that to pass.