### PR TITLE
Fixed build and run-time crash.

### DIFF
--- a/src/DwarfMap.hpp
+++ b/src/DwarfMap.hpp
@@ -6,7 +6,7 @@
 #include <map>
 #include <stdint.h>
 #include <libdwarf/libdwarf.h>
-#include <dwarf.h>
+#include <libdwarf/dwarf.h>
 #include <gtirb/gtirb.hpp>
 #include "AuxDataSchema.h"
 

--- a/src/disasm_main.cpp
+++ b/src/disasm_main.cpp
@@ -91,6 +91,8 @@ void registerAuxDataTypes()
     gtirb::AuxDataContainer::registerAuxDataType<SymbolicOperandInfoAD>();
     gtirb::AuxDataContainer::registerAuxDataType<Encodings>();
     gtirb::AuxDataContainer::registerAuxDataType<ElfSectionProperties>();
+    gtirb::AuxDataContainer::registerAuxDataType<AllElfSectionProperties>();
+    gtirb::AuxDataContainer::registerAuxDataType<DWARFElfSectionProperties>();
     gtirb::AuxDataContainer::registerAuxDataType<PeSectionProperties>();
     gtirb::AuxDataContainer::registerAuxDataType<CfiDirectives>();
     gtirb::AuxDataContainer::registerAuxDataType<Libraries>();


### PR DESCRIPTION
Fixed an incorrect header and registered the new dwarf-related auxiliary datatypes to get it building and running again.