### PR TITLE
Refactor dl arch selection so it works

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,7 +56,7 @@ add_custom_command(OUTPUT ${GENERATED_CPP_ARM64}
     # program name. Change directory and use a relative path so the name
     # does not depend on build location.
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/"
-    COMMAND ${SOUFFLE} ${SOUFFLE_DISASM_MAIN} -g souffle_disasm_aarch64.cpp -jauto -MARCH=ARM64
+    COMMAND ${SOUFFLE} ${SOUFFLE_DISASM_MAIN} -g souffle_disasm_aarch64.cpp -jauto -MARCH_ARM64
     DEPENDS ${DATALOG_BASE_SOURCES} ${DATALOG_AARCH64_SOURCES})
 
 set(GENERATED_CPP_X64 "${CMAKE_BINARY_DIR}/src/souffle_disasm_x64.cpp")
@@ -65,7 +65,7 @@ set(GENERATED_CPP_X64 "${CMAKE_BINARY_DIR}/src/souffle_disasm_x64.cpp")
     # program name. Change directory and use a relative path so the name
     # does not depend on build location.
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/src/"
-    COMMAND ${SOUFFLE} ${SOUFFLE_DISASM_MAIN} -g souffle_disasm_x64.cpp -jauto -MARCH=X64
+    COMMAND ${SOUFFLE} ${SOUFFLE_DISASM_MAIN} -g souffle_disasm_x64.cpp -jauto -MARCH_AMD64
     DEPENDS ${DATALOG_BASE_SOURCES} ${DATALOG_X64_SOURCES})
 
 # determine what flags to use to specify -fopenmp.

--- a/src/datalog/main.dl
+++ b/src/datalog/main.dl
@@ -64,18 +64,14 @@ This module:
 #include "elf_binaries.dl"
 
 // architecture specific predicates
-#ifndef ARCH
-    #define ARCH X64
-#endif
-
-#if ARCH == ARM64
+#ifdef ARCH_ARM64
     #include "aarch64/arch_aarch64.dl"
     .init arch = ARM64
-#elif ARCH == X64
+#elif defined(ARCH_AMD64)
     #include "x64/arch_x64.dl"
     .init arch = X64
 #else
-    #error "Undefined value for ARCH"
+    #error "Undefined architecture"
 #endif
 
 // tables with basic facts


### PR DESCRIPTION
Our current approach to selecting datalog to include is buggy. It attempts to use string comparison in #if statements that does not work as expected. We need to either use enums (effectively), or unique identifiers that we check are defined