### PR TITLE
Added `--arch` option.

### DIFF
--- a/src/GtirbZeroBuilder.cpp
+++ b/src/GtirbZeroBuilder.cpp
@@ -253,12 +253,13 @@ std::tuple<gtirb::IR*, LIEF::ARCHITECTURES, LIEF::ENDIANNESS> buildZeroIR(const 
 {
     // Parse binary file
     std::shared_ptr<BinaryReader> binary(new LIEFBinaryReader(filename));
-    LIEF::ARCHITECTURES arch;
-    LIEF::ENDIANNESS endianness;
-    std::tie(arch, endianness) = binary->get_container_info();
 
     if(!binary->is_valid())
         return std::make_tuple(nullptr, LIEF::ARCHITECTURES::ARCH_NONE, LIEF::ENDIANNESS::ENDIAN_NONE);
+
+    LIEF::ARCHITECTURES arch;
+    LIEF::ENDIANNESS endianness;
+    std::tie(arch, endianness) = binary->get_container_info();
 
     // Intialize IR and Module
     auto ir = gtirb::IR::Create(context);

--- a/src/LIEFBinaryReader.cpp
+++ b/src/LIEFBinaryReader.cpp
@@ -31,7 +31,7 @@ LIEFBinaryReader::LIEFBinaryReader(const std::string& filename)
 
 bool LIEFBinaryReader::is_valid()
 {
-    return bin->format() == LIEF::EXE_FORMATS::FORMAT_ELF;
+    return bin != nullptr && bin->format() == LIEF::EXE_FORMATS::FORMAT_ELF;
 }
 
 

--- a/src/disasm_main.cpp
+++ b/src/disasm_main.cpp
@@ -108,6 +108,8 @@ int main(int argc, char **argv)
         ("ir", po::value<std::string>(), "GTIRB output file")           //
         ("json", po::value<std::string>(), "GTIRB json output file")    //
         ("asm", po::value<std::string>(), "ASM output file")            //
+        ("arch", po::value<std::string>(),
+         "Set binary architecture (arm64 or x64). Automatically detected if not set.") //
         ("dwarf", "Dwarf analysis")
         ("debug", "generate assembler file with debugging information") //
         ("debug-dir", po::value<std::string>(),                         //
@@ -166,6 +168,23 @@ int main(int argc, char **argv)
     LIEF::ARCHITECTURES lief_arch;
     LIEF::ENDIANNESS endianness;
     std::tie(ir, lief_arch, endianness) = buildZeroIR(filename, context);
+
+    if (vm.count("arch") != 0) {
+        std::string arch_opt_value = vm["arch"].as<std::string>();
+        LIEF::ARCHITECTURES set_arch;
+        if (arch_opt_value == "x64")
+            set_arch = LIEF::ARCHITECTURES::ARCH_X86;
+        else if (arch_opt_value == "arm64")
+            set_arch = LIEF::ARCHITECTURES::ARCH_ARM64;
+        else {
+            std::cerr << "Error: unsupported architecture chosen with --arch flag" << std::endl;
+            return 1;
+        }
+
+        if (set_arch != lief_arch)
+            std::cerr << "Warning: detected architecture differs from set architecture" << std::endl;
+        lief_arch = set_arch;
+    }
 
     if(!ir)
     {


### PR DESCRIPTION
Can now choose the architecture (`x64` or `arm64`) as a command line option using `--arch`.

```
ddisasm blah --arch=arm64
```

Also, fixed the segfault when an invalid binary is passed in.